### PR TITLE
fonttools 4.51.0

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,2 @@
+channels:  
+  - https://staging.continuum.io/prefect/fs/unicodedata2-feedstock/pr4/7273be5

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,2 +1,0 @@
-channels:  
-  - https://staging.continuum.io/prefect/fs/unicodedata2-feedstock/pr4/7273be5

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -36,7 +36,9 @@ requirements:
     - brotli >=1.0.1
     - unicodedata2 >=15.1.0 # [py<313]
   run_constrained:
+    - fs >=2.2.0,< 3
     - lxml >=4.0
+    - zopfli >=0.1.4
     - lz4 >=1.7.4.2
     - skia-pathops >=0.5.0
     - uharfbuzz >=0.23.0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "fonttools" %}
-{% set version = "4.25.0" %}
-{% set sha256 = "618f1ecb7f328c17164e4c9a11fdf8945164eb764ff11a2a17a368720ecc892e" %}
+{% set version = "4.49.0" %}
+{% set sha256 = "90f9ed4782e756e15a8603343d33adc13399306a963f55f8c8f2762a00a82f01" %}
 
 package:
   name: {{ name|lower }}
@@ -12,7 +12,6 @@ source:
   sha256: {{ sha256 }}
 
 build:
-  noarch: python
   number: 0
   script: python setup.py install --single-version-externally-managed --record record.txt
   entry_points:
@@ -23,12 +22,12 @@ build:
 
 requirements:
   host:
-    - python >=3.6
+    - python
     - setuptools
     - pip
     - wheel
   run:
-    - python >=3.6
+    - python
     # for fontTools.sfnt and fontTools.woff2: to compress/uncompress
     # WOFF 1.0 and WOFF 2.0 webfonts.
     - brotli >=1.0.1

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -23,6 +23,7 @@ build:
 requirements:
   host:
     - python
+    - cython
     - setuptools
     - pip
     - wheel
@@ -33,7 +34,7 @@ requirements:
     - brotli >=1.0.1
     # 5/17/2021: the unicodedata2 extension module doesn't work on PyPy.
     # Python 3.9 already has Unicode 13.0, so the backport is not needed.
-    #- unicodedata2 >=15.1.0  # [py<313]
+    - unicodedata2 >=14.0.0 # [py<311]
   run_constrained:
     - lxml >=4.0
     - lz4 >=1.7.4.2

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "fonttools" %}
-{% set version = "4.49.0" %}
-{% set sha256 = "90f9ed4782e756e15a8603343d33adc13399306a963f55f8c8f2762a00a82f01" %}
+{% set version = "4.51.0" %}
+{% set sha256 = "85aa9cdf030dd82f28ca584a8814de265150b46bfc65067343a631773efa885a" %}
 
 package:
   name: {{ name|lower }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -62,8 +62,8 @@ about:
     supports TrueType, OpenType, AFM and to an extent Type 1 and some
     Mac-specific formats. The project has a BSD-style open-source licence.
 
-  doc_url: https://fonttools.readthedocs.io/en/latest/
-  dev_url: https://fonttools.readthedocs.io/
+  doc_url: https://fonttools.readthedocs.io/
+  dev_url: https://github.com/fonttools/fonttools
 
 extra:
   recipe-maintainers:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -36,7 +36,7 @@ requirements:
     - brotli >=1.0.1
     - unicodedata2 >=15.1.0 # [py<313]
   run_constrained:
-    - fs >=2.2.0,< 3
+    - fs >=2.2.0,<3
     - lxml >=4.0
     - zopfli >=0.1.4
     - lz4 >=1.7.4.2

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,7 +13,7 @@ source:
 
 build:
   number: 0
-  script: python setup.py install --single-version-externally-managed --record record.txt
+  script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
   entry_points:
     - fonttools = fontTools.__main__:main
     - ttx = fontTools.ttx:main

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -61,7 +61,7 @@ about:
     supports TrueType, OpenType, AFM and to an extent Type 1 and some
     Mac-specific formats. The project has a BSD-style open-source licence.
 
-  doc_url: https://groups.google.com/forum/#!forum/fonttools
+  doc_url: https://fonttools.readthedocs.io/en/latest/
   dev_url: https://github.com/fonttools/fonttools
 
 extra:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -19,8 +19,12 @@ build:
     - ttx = fontTools.ttx:main
     - pyftsubset = fontTools.subset:main
     - pyftmerge = fontTools.merge:main
+  script_env:
+    - FONTTOOLS_WITH_CYTHON=1
 
 requirements:
+  build:
+    - {{ compiler('c') }}
   host:
     - python
     - cython
@@ -46,6 +50,8 @@ test:
     - fonttools subset --help
     - ttx -h
     - pyftsubset --help
+    - echo $FONTTOOLS_WITH_CYTHON
+    - python -c "from fontTools.cu2qu.cu2qu import COMPILED; assert COMPILED"
     # pyftmerge has no help option
     # pyftinspect requires gtk
   requires:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -33,8 +33,12 @@ requirements:
     - brotli >=1.0.1
     # 5/17/2021: the unicodedata2 extension module doesn't work on PyPy.
     # Python 3.9 already has Unicode 13.0, so the backport is not needed.
-    - unicodedata2 >=13.0.0  # [py<39 and (python_impl != "pypy")]
-    - munkres
+    - unicodedata2 >= 15.1.0  # [py<313]
+    - lxml >=4.0
+    - lz4 >=1.7.4.2
+    - skia-pathops >=0.5.0
+    - uharfbuzz >=0.23.0
+
 
 test:
   imports:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -29,18 +29,13 @@ requirements:
     - wheel
   run:
     - python
-    # for fontTools.sfnt and fontTools.woff2: to compress/uncompress
-    # WOFF 1.0 and WOFF 2.0 webfonts.
     - brotli >=1.0.1
-    # 5/17/2021: the unicodedata2 extension module doesn't work on PyPy.
-    # Python 3.9 already has Unicode 13.0, so the backport is not needed.
-    - unicodedata2 >=14.0.0 # [py<311]
+    - unicodedata2 >=15.1.0 # [py<313]
   run_constrained:
     - lxml >=4.0
     - lz4 >=1.7.4.2
     - skia-pathops >=0.5.0
     - uharfbuzz >=0.23.0
-
 
 test:
   imports:
@@ -68,7 +63,7 @@ about:
     Mac-specific formats. The project has a BSD-style open-source licence.
 
   doc_url: https://fonttools.readthedocs.io/en/latest/
-  dev_url: https://github.com/fonttools/fonttools
+  dev_url: https://fonttools.readthedocs.io/
 
 extra:
   recipe-maintainers:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -33,7 +33,8 @@ requirements:
     - brotli >=1.0.1
     # 5/17/2021: the unicodedata2 extension module doesn't work on PyPy.
     # Python 3.9 already has Unicode 13.0, so the backport is not needed.
-    - unicodedata2 >= 15.1.0  # [py<313]
+    #- unicodedata2 >=15.1.0  # [py<313]
+  run_constrained:
     - lxml >=4.0
     - lz4 >=1.7.4.2
     - skia-pathops >=0.5.0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -42,11 +42,14 @@ test:
     - fontTools
     - fontTools.ttLib
   commands:
+    - pip check
     - fonttools subset --help
     - ttx -h
     - pyftsubset --help
     # pyftmerge has no help option
     # pyftinspect requires gtk
+  requires:
+    - pip
 
 about:
   home: https://github.com/fonttools/fonttools


### PR DESCRIPTION
fonttools 4.51.0

**Destination channel:** defaults

Needs update due to being effected by [CVE-2023-45139](https://anaconda.atlassian.net/browse/CVE-745)

### Links

- [PKG-4006](https://anaconda.atlassian.net/browse/PKG-4006) 
- [Upstream repository](https://github.com/fonttools/fonttools)
- [Upstream changelog/diff](https://github.com/fonttools/fonttools/compare/4.45.0...4.51.0)
- Relevant dependency PR:
             - https://github.com/AnacondaRecipes/unicodedata2-feedstock/pull/4


### Explanation of changes:

- updated version and SHA


[PKG-4006]: https://anaconda.atlassian.net/browse/PKG-4006?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ