### PR TITLE
fonttools 4.63.0 

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -54,6 +54,7 @@ test:
     - Tests
     - MetaTools
     - Doc
+    - Lib
   imports:
     - fontTools
     - fontTools.cffLib

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -52,6 +52,7 @@ requirements:
 test:
   source_files:
     - Tests
+    - MetaTools
   imports:
     - fontTools
     - fontTools.cffLib

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "fonttools" %}
-{% set version = "4.62.1" %}
+{% set version = "4.63.0" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://github.com/{{ name }}/{{ name }}/archive/{{ version }}.tar.gz
-  sha256: 9207dc3e2a8e3212986b1cdbe0696f6cebcf1a1d6de93cce11c2d85afb2a35dc
+  sha256: fa9b285d407536e620b02365adb2c911d9d93237ea66404dfbbeb197199b9c8e
 
 build:
   number: 0
@@ -28,8 +28,9 @@ requirements:
   host:
     - pip
     - python
-    - cython
+    - wheel
     - setuptools
+    - cython
   run:
     - python
   run_constrained:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -53,6 +53,7 @@ test:
   source_files:
     - Tests
     - MetaTools
+    - Doc
   imports:
     - fontTools
     - fontTools.cffLib


### PR DESCRIPTION
fonttools 4.63.0 

**Destination channel:** Defaults

### Links

- [PKG-15110]
- dev_url:        https://github.com/fonttools/fonttools/tree/4.63.0
- conda_forge:    https://github.com/conda-forge/fonttools-feedstock
- pypi:           https://pypi.org/project/fonttools/4.63.0
- pypi inspector: https://inspector.pypi.io/project/fonttools/4.63.0

### Explanation of changes:

- new version number


[PKG-15110]: https://anaconda.atlassian.net/browse/PKG-15110?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ